### PR TITLE
Fixed bug with fwrite failure check on writing empty files

### DIFF
--- a/src/AutoUpdate.php
+++ b/src/AutoUpdate.php
@@ -775,7 +775,7 @@ class AutoUpdate
                 return false;
             }
 
-            if (!fwrite($updateHandle, $contents)) {
+            if (fwrite($updateHandle, $contents) === false) {
                 $this->_log->addError(sprintf('Could not write to file "%s"!', $absoluteFilename));
                 zip_close($zip);
 


### PR DESCRIPTION
fwrite() returns the bytes written or false on error. While writing empty files like ".gitkeep", the value returned is 0. So the failure check condition should check for "false".